### PR TITLE
Hide tooltips on workspace details page

### DIFF
--- a/src/app/workspaces/list-workspaces/workspace-item/workspace-item.html
+++ b/src/app/workspaces/list-workspaces/workspace-item/workspace-item.html
@@ -40,6 +40,7 @@
         <span class="che-xs-header noselect" hide-gt-xs>Name</span>
         <div layout="row" flex>
           <workspace-status-indicator che-status="workspaceItemCtrl.getWorkspaceStatus()"
+                                      tooltip-enabled="true"
                                       flex="none"></workspace-status-indicator>
           <div class="workspace-name-clip"
                id="ws-full-name-{{workspaceItemCtrl.workspace.namespace}}/{{workspaceItemCtrl.workspaceName}}">

--- a/src/app/workspaces/workspace-status/workspace-status-indicator.directive.ts
+++ b/src/app/workspaces/workspace-status/workspace-status-indicator.directive.ts
@@ -29,7 +29,8 @@ export class WorkspaceStatusIndicator implements ng.IDirective {
     this.replace = true;
 
     this.scope = {
-      status: '=cheStatus'
+      status: '=cheStatus',
+      tooltipEnabled: '=tooltipEnabled'
     };
   }
 
@@ -43,16 +44,16 @@ export class WorkspaceStatusIndicator implements ng.IDirective {
     let emptyCircleOnStopped = ($attrs as any).cheEmptyCircle;
 
     return '<span ng-switch="status" class="workspace-status-indicator">' +
-      '<span ng-switch-when="STOPPED" uib-tooltip="Workspace Stopped" class="fa ' + (emptyCircleOnStopped ? 'fa-circle-o' : 'fa-circle') + ' workspace-status-stopped"></span>' +
-      '<span ng-switch-when="PAUSED" class="fa fa-pause workspace-status-paused"></span>' +
-      '<span ng-switch-when="RUNNING" uib-tooltip="Workspace Running" class="fa fa-circle workspace-status-running"></span>' +
-      '<span ng-switch-when="STARTING" uib-tooltip="Workspace Starting" class="workspace-status-spinner">' +
+      '<span ng-switch-when="STOPPED" uib-tooltip="Workspace Stopped" tooltip-placement="top" tooltip-enable="tooltipEnabled" class="fa ' + (emptyCircleOnStopped ? 'fa-circle-o' : 'fa-circle') + ' workspace-status-stopped"></span>' +
+      '<span ng-switch-when="PAUSED" uib-tooltip="Workspace Paused" tooltip-placement="top" tooltip-enable="{{tooltipEnabled}}" class="fa fa-pause workspace-status-paused"></span>' +
+      '<span ng-switch-when="RUNNING" uib-tooltip="Workspace Running" tooltip-placement="top" tooltip-enable="{{tooltipEnabled}}" class="fa fa-circle workspace-status-running"></span>' +
+      '<span ng-switch-when="STARTING" uib-tooltip="Workspace Starting" tooltip-placement="top" tooltip-enable="{{tooltipEnabled}}" class="workspace-status-spinner">' +
       '<div class="spinner"><div class="rect1"></div><div class="rect2"></div><div class="rect3"></div></div>' +
       '</span>' +
-      '<span ng-switch-when="STOPPING" uib-tooltip="Workspace Stopping" class="workspace-status-spinner">' +
+      '<span ng-switch-when="STOPPING" uib-tooltip="Workspace Stopping" tooltip-placement="top" tooltip-enable="{{tooltipEnabled}}" class="workspace-status-spinner">' +
       '<div class="spinner"><div class="rect1"></div><div class="rect2"></div><div class="rect3"></div></div>' +
       '</span>' +
-      '<span ng-switch-when="ERROR" uib-tooltip="Workspace Error" class="fa fa-circle workspace-status-error"></span>' +
+      '<span ng-switch-when="ERROR" uib-tooltip="Workspace Error" tooltip-placement="top" tooltip-enable="{{tooltipEnabled}}" class="fa fa-circle workspace-status-error"></span>' +
       '<span ng-switch-default class="fa ' + (emptyCircleOnStopped ? 'fa-circle-o' : 'fa-circle') + ' workspace-status-default"></span>' +
       '</span>';
   }


### PR DESCRIPTION
This PR changes the default behavior for workspace tooltips so that they are hidden by default, and enabled on the workspace listings page. This was because the tooltips go off screen on the workspace details page and are redundant because on this page the workspace status has a label next to the indicator which is not present on the workspace listings page.