### PR TITLE
Updates/revert left nav links removal

### DIFF
--- a/src/assets/branding/product.json
+++ b/src/assets/branding/product.json
@@ -25,5 +25,39 @@
     "factory" : "/docs/factories-getting-started.html",
     "organization": "/docs/organizations.html",
     "general": "/docs"
+  },
+  "maapLinks": {
+    "portalHome": {
+      "reference": "{{PORTAL}}/",
+      "title": "MAAP Homepage",
+      "longTitle": "MAAP Homepage",
+      "envSpecific": true
+    },
+    "userGuides": {
+      "reference": "{{PORTAL}}/user-guides/",
+      "title": "User Guides",
+      "longTitle": "User Guides",
+      "envSpecific": true
+    },
+    "issues": {
+      "reference": "https://github.com/MAAP-Project/ZenHub/issues",
+      "title": "Report an Issue",
+      "longTitle": "Report an Issue"
+    },
+    "openPolicies": {
+      "reference": "{{PORTAL}}/open-policies/",
+      "title": "Open Policies",
+      "longTitle": "Open Policies",
+      "envSpecific": true
+    },
+    "tos": {
+      "reference": "{{PORTAL}}/terms-of-service/",
+      "title": "TOS",
+      "longTitle": "Terms of Service",
+      "envSpecific": true
+    }
+  },
+  "maapServiceHosts": {
+    "PORTAL": "https://{{ENV}}.maap-project.org"
   }
 }

--- a/src/components/branding/branding.constant.ts
+++ b/src/components/branding/branding.constant.ts
@@ -53,9 +53,7 @@ export const jsonBranding = JSON.stringify({
   'configuration': {
     'menu': {
       'disabled': [
-        'administration',
-        'factories',
-        'organizations'
+        'factories'
       ]
     },
     'features': {

--- a/src/components/branding/branding.constant.ts
+++ b/src/components/branding/branding.constant.ts
@@ -68,40 +68,6 @@ export const jsonBranding = JSON.stringify({
     'content': '',
     'links': [],
     'email': ''
-  },
-  'maapLinks': {
-    'portalHome': {
-      'reference': '{{PORTAL}}/',
-      'title': 'MAAP Homepage',
-      'longTitle': 'MAAP Homepage',
-      'envSpecific': true
-    },
-    'userGuides': {
-      'reference': '{{PORTAL}}/user-guides/',
-      'title': 'User Guides',
-      'longTitle': 'User Guides',
-      'envSpecific': true
-    },
-    'issues': {
-      'reference': 'https://github.com/MAAP-Project/ZenHub/issues',
-      'title': 'Report an Issue',
-      'longTitle': 'Report an Issue'
-    },
-    'openPolicies': {
-      'reference': '{{PORTAL}}/open-policies/',
-      'title': 'Open Policies',
-      'longTitle': 'Open Policies',
-      'envSpecific': true
-    },
-    'tos': {
-      'reference': '{{PORTAL}}/terms-of-service/',
-      'title': 'TOS',
-      'longTitle': 'Terms of Service',
-      'envSpecific': true
-    }
-  },
-  'maapServiceHosts': {
-    'PORTAL': 'https://{{ENV}}.maap-project.org'
   }
 }
 );

--- a/src/components/branding/branding.json
+++ b/src/components/branding/branding.json
@@ -51,39 +51,5 @@
     "content": "",
     "links": [],
     "email": ""
-  },
-  "maapLinks": {
-    "portalHome": {
-      "reference": "{{PORTAL}}/",
-      "title": "MAAP Homepage",
-      "longTitle": "MAAP Homepage",
-      "envSpecific": true
-    },
-    "userGuides": {
-      "reference": "{{PORTAL}}/user-guides/",
-      "title": "User Guides",
-      "longTitle": "User Guides",
-      "envSpecific": true
-    },
-    "issues": {
-      "reference": "https://github.com/MAAP-Project/ZenHub/issues",
-      "title": "Report an Issue",
-      "longTitle": "Report an Issue"
-    },
-    "openPolicies": {
-      "reference": "{{PORTAL}}/open-policies/",
-      "title": "Open Policies",
-      "longTitle": "Open Policies",
-      "envSpecific": true
-    },
-    "tos": {
-      "reference": "{{PORTAL}}/terms-of-service/",
-      "title": "TOS",
-      "longTitle": "Terms of Service",
-      "envSpecific": true
-    }
-  },
-  "maapServiceHosts": {
-    "PORTAL": "https://{{ENV}}.maap-project.org"
   }
 }

--- a/src/components/branding/branding.json
+++ b/src/components/branding/branding.json
@@ -36,9 +36,7 @@
   "configuration": {
     "menu": {
       "disabled": [
-        "administration",
-        "factories",
-        "organizations"
+        "factories"
       ]
     },
     "features": {


### PR DESCRIPTION
There are two changes in this PR:

1. I've reverted the previous change of hiding the "Organizations" and "Administration" link in the left nav.  The removal of the "Organizations" link caused the share workspace feature to be disabled.
2. Moved footer links info from `branding.json` to `product.json` after learning that MAAP specific info is contained in `product.json`.