### PR TITLE
Updated the link we reference for "Learn More" in the workspaces view…

### DIFF
--- a/src/assets/branding/product.json
+++ b/src/assets/branding/product.json
@@ -20,11 +20,7 @@
     "name" : "CHE"
   },
   "docs" : {
-    "stack" : "/docs/creating-starting-workspaces.html",
-    "workspace" : "/docs/what-are-workspaces.html",
-    "factory" : "/docs/factories-getting-started.html",
-    "organization": "/docs/organizations.html",
-    "general": "/docs"
+    "workspace" : "https://www.eclipse.org/che/docs/stable/overview/introduction-to-eclipse-che/#_workspace_model"
   },
   "maapLinks": {
     "portalHome": {


### PR DESCRIPTION
Changes in this PR:

* Updated the link that is referenced for "learn more" in the workspaces tab
* Removed all the other links referenced in the `docs` key in `products.json` as they weren't working. And because they override the default `docs` values from `branding.json` it didn't seem prudent to keep these around.

Further details can be found [here](https://github.com/MAAP-Project/ZenHub/issues/634#issuecomment-1370282948)