### PR TITLE
Fix workspace deletion confirmation dialog

### DIFF
--- a/src/components/service/confirm-dialog/che-confirm-dialog.styl
+++ b/src/components/service/confirm-dialog/che-confirm-dialog.styl
@@ -2,7 +2,6 @@
   width 100%
   margin-top 10px
   min-height 50px
-  pointer-events none
 
   div:last-child
     margin 15px 0 0 0
@@ -10,3 +9,6 @@
     button
       margin 0 0 0 10px
       pointer-events auto
+
+.che-confirm-dialog-notification :not(input)
+  pointer-events none


### PR DESCRIPTION
### What does this PR do?

This PR resolves a user's inability to delete a workspace when the confirm dialog box asks for their acknowledgement.

In summary, the pointer events for the Che confirm dialog service were modified so that one-offs of it can continue to function when additional input elements are added that require interactivity, like the delete workspace dialog that asks for user acknowledgement.

### What issues does this PR fix or reference?

https://github.com/MAAP-Project/ZenHub/issues/711
